### PR TITLE
fixed broken API call

### DIFF
--- a/final/index.html
+++ b/final/index.html
@@ -123,11 +123,11 @@ limitations under the License.
 
       // See https://developer.yahoo.com/weather/
       t._calculateWeatherParams = function(latitude, longitude) {
-        var latLongString = latitude + ',' + longitude;
+        var latLongString = '(' + latitude + ',' + longitude + ')';
         return {
           format: 'json',
           q: 'select * from weather.forecast where woeid in ' +
-             '(SELECT woeid FROM geo.placefinder WHERE text="' + latLongString + '" and gflags="R")'
+             '(SELECT woeid FROM geo.places(1) WHERE text="' + latLongString + '")'
         };
       };
 

--- a/step1/index.html
+++ b/step1/index.html
@@ -111,11 +111,11 @@ limitations under the License.
 
       // See https://developer.yahoo.com/weather/
       t._calculateWeatherParams = function(latitude, longitude) {
-        var latLongString = latitude + ',' + longitude;
+        var latLongString = '(' + latitude + ',' + longitude + ')';
         return {
           format: 'json',
           q: 'select * from weather.forecast where woeid in ' +
-             '(SELECT woeid FROM geo.placefinder WHERE text="' + latLongString + '" and gflags="R")'
+             '(SELECT woeid FROM geo.places(1) WHERE text="' + latLongString + '")'
         };
       };
 

--- a/step2/index.html
+++ b/step2/index.html
@@ -118,11 +118,11 @@ limitations under the License.
 
       // See https://developer.yahoo.com/weather/
       t._calculateWeatherParams = function(latitude, longitude) {
-        var latLongString = latitude + ',' + longitude;
+        var latLongString = '(' + latitude + ',' + longitude + ')';
         return {
           format: 'json',
           q: 'select * from weather.forecast where woeid in ' +
-             '(SELECT woeid FROM geo.placefinder WHERE text="' + latLongString + '" and gflags="R")'
+             '(SELECT woeid FROM geo.places(1) WHERE text="' + latLongString + '")'
         };
       };
 


### PR DESCRIPTION
As mentioned [here](http://stackoverflow.com/questions/34904938/yahoo-yql-query-with-gflags-returns-nothing) the query is now geo.places(1) instead of geo.placefinder, also removing gflags and adding brackets to the latitude/longitude.

Fixes #3 
